### PR TITLE
#87 Added docker environment variable for CORS headers

### DIFF
--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -9,6 +9,7 @@ services:
             - OPENVALIDATION_IDE_DB_NAME=openvalidation_ide
             - OPENVALIDATION_IDE_DB_USER=openvalidation_ide
             - OPENVALIDATION_IDE_DB_PW=_OPeN_VALiDAtION_IdE
+            - CORS_HEADERS=https://openvalidation-ide-ui.azurewebsites.net
         build:
             context: .
         depends_on:

--- a/backend/src/main/java/de/openvalidation/openvalidationidebackend/config/WebConfig.java
+++ b/backend/src/main/java/de/openvalidation/openvalidationidebackend/config/WebConfig.java
@@ -1,0 +1,21 @@
+package de.openvalidation.openvalidationidebackend.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+@EnableWebMvc
+public class WebConfig implements WebMvcConfigurer {
+
+  @Value("${cors-headers}")
+  private String corsHeaders;
+
+  @Override
+  public void addCorsMappings(CorsRegistry registry) {
+    registry.addMapping("/**")
+        .allowedOrigins(corsHeaders.trim().concat(",http://localhost").split("\\s*,\\s*"));
+  }
+}

--- a/backend/src/main/java/de/openvalidation/openvalidationidebackend/entities/ruleset/RulesetController.java
+++ b/backend/src/main/java/de/openvalidation/openvalidationidebackend/entities/ruleset/RulesetController.java
@@ -10,7 +10,6 @@ import javax.validation.Valid;
 import java.util.List;
 import java.util.UUID;
 
-@CrossOrigin
 @RestController
 public class RulesetController {
   private RulesetService rulesetService;

--- a/backend/src/main/java/de/openvalidation/openvalidationidebackend/entities/schema/SchemaController.java
+++ b/backend/src/main/java/de/openvalidation/openvalidationidebackend/entities/schema/SchemaController.java
@@ -17,7 +17,6 @@ import java.util.Set;
 import java.util.UUID;
 
 @RestController
-@CrossOrigin
 public class SchemaController {
   private SchemaService schemaService;
 

--- a/backend/src/main/java/de/openvalidation/openvalidationidebackend/maintenance/ResetController.java
+++ b/backend/src/main/java/de/openvalidation/openvalidationidebackend/maintenance/ResetController.java
@@ -3,14 +3,12 @@ package de.openvalidation.openvalidationidebackend.maintenance;
 import io.swagger.v3.oas.annotations.Hidden;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.sql.SQLException;
 
-@CrossOrigin
 @RestController
 @Hidden
 public class ResetController {

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -25,3 +25,5 @@ springdoc:
     path: /swagger-ui
     displayRequestDuration: true
     tagsSorter: alpha
+
+cors-headers: ${CORS_HEADERS:#{"null"}}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,7 @@ services:
             - OPENVALIDATION_IDE_DB_NAME=openvalidation_ide
             - OPENVALIDATION_IDE_DB_USER=openvalidation_ide
             - OPENVALIDATION_IDE_DB_PW=_OPeN_VALiDAtION_IdE
+            - CORS_HEADERS=https://openvalidation-ide-ui.azurewebsites.net
         ports:
             - "8080:8080"
         depends_on:


### PR DESCRIPTION
Run container with e.g.: docker run --env CORS_HEADERS=https://openvalidation-ide-ui.azurewebsites.net
You can also append a comma separated list with multiple origins.